### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Jcounts517/jsn-docs/security/code-scanning/1](https://github.com/Jcounts517/jsn-docs/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the least privileges required for the workflow to function correctly. Since the workflow primarily checks out the repository and runs scripts, it only needs `contents: read` permissions. This ensures that the `GITHUB_TOKEN` has minimal access, reducing the risk of unintended modifications or security vulnerabilities.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`build`) to limit permissions for that job only. In this case, adding it at the root level is sufficient and ensures consistency across all jobs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
